### PR TITLE
Docker java update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN groupadd --gid 1000 -r ${TOMCAT_GROUP} && \
 
 # Copy WAR to webapps folder
 COPY --from=builder --chown=1000:1000 /build/build/install/3DCityDB-Web-Feature-Service/citydb-wfs.war \
-       ${CATALINA_HOME}/webapps/ROOT.war
+     ${CATALINA_HOME}/webapps/ROOT.war
 
 COPY --chown=1000:1000 resources/docker/citydb-wfs-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='11.0.12-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='9-jdk11'
+ARG BUILDER_IMAGE_TAG='17-jdk-slim'
+ARG RUNTIME_IMAGE_TAG='9-jdk17'
 
 # Base image
 FROM openjdk:${BUILDER_IMAGE_TAG} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Fetch & build stage #########################################################
 # ARGS
 ARG BUILDER_IMAGE_TAG='17-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='9-jdk17'
+ARG RUNTIME_IMAGE_TAG='9-jdk17-openjdk-slim'
 
 # Base image
 FROM openjdk:${BUILDER_IMAGE_TAG} AS builder

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -5,7 +5,7 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='11.0.12-jdk-slim'
+ARG BUILDER_IMAGE_TAG='17-jdk-slim'
 ARG RUNTIME_IMAGE_TAG='9-alpine'
 
 # Base image

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -37,7 +37,7 @@ RUN addgroup -g 1000 -S ${TOMCAT_GROUP} && \
 
 # Copy WAR to webapps folder
 COPY --from=builder --chown=1000:1000 /build/build/install/3DCityDB-Web-Feature-Service/citydb-wfs.war \
-       ${CATALINA_HOME}/webapps/ROOT.war
+     ${CATALINA_HOME}/webapps/ROOT.war
 
 COPY --chown=1000:1000 resources/docker/citydb-wfs-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,7 @@
 # Fetch & build stage #########################################################
 # ARGS
 ARG BUILDER_IMAGE_TAG='17-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='9-alpine'
+ARG RUNTIME_IMAGE_TAG='17'
 
 # Base image
 FROM openjdk:${BUILDER_IMAGE_TAG} AS builder
@@ -25,28 +25,35 @@ RUN chmod u+x ./gradlew && ./gradlew installDist
 
 # Runtime stage ###############################################################
 # Base image
-FROM tomcat:${RUNTIME_IMAGE_TAG} AS runtime
+FROM bellsoft/liberica-openjdk-alpine:${RUNTIME_IMAGE_TAG} AS runtime
 
-ARG TOMCAT_USER='tomcat'
-ARG TOMCAT_GROUP='tomcat'
+ARG TOMCAT_USER='tomcat9'
+ARG TOMCAT_GROUP='tomcat9'
+ENV CATALINA_HOME=/usr/share/tomcat9
 
-# Run as non-root user user
-RUN addgroup -g 1000 -S ${TOMCAT_GROUP} && \
-    adduser -u 1000 -G ${TOMCAT_USER} -h /citydb-wfs -S ${TOMCAT_USER} && \
-    chown -R 1000:1000 ${CATALINA_HOME}
+# Install Tomcat
+RUN set -ex && \
+    apk add --update-cache --no-cache \
+        --virtual runtime-deps \
+        -X https://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+        tomcat9 bash && \
+    chmod -v u+x ${CATALINA_HOME}/bin/catalina.sh && \
+    ln -s -v ${CATALINA_HOME}/bin/catalina.sh /usr/bin/catalina.sh
 
 # Copy WAR to webapps folder
-COPY --from=builder --chown=1000:1000 /build/build/install/3DCityDB-Web-Feature-Service/citydb-wfs.war \
-       ${CATALINA_HOME}/webapps/ROOT.war
+COPY --from=builder --chown=${TOMCAT_USER}:${TOMCAT_GROUP} \
+    /build/build/install/3DCityDB-Web-Feature-Service/citydb-wfs.war \
+    ${CATALINA_HOME}/webapps/ROOT.war
 
-COPY --chown=1000:1000 resources/docker/citydb-wfs-entrypoint.sh /usr/local/bin/
+COPY --chown=${TOMCAT_USER}:${TOMCAT_GROUP} \
+    resources/docker/citydb-wfs-entrypoint.sh /usr/local/bin/
 
 # Delete existing ROOT context and set permissions
 RUN rm -rf ${CATALINA_HOME}/webapps/ROOT && \
     chmod a+x /usr/local/bin/citydb-wfs-entrypoint.sh
 
 WORKDIR /citydb-wfs
-USER 1000
+USER 100
 EXPOSE 8080
 
 ENTRYPOINT ["citydb-wfs-entrypoint.sh"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,7 @@
 # Fetch & build stage #########################################################
 # ARGS
 ARG BUILDER_IMAGE_TAG='17-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='17'
+ARG RUNTIME_IMAGE_TAG='9-alpine'
 
 # Base image
 FROM openjdk:${BUILDER_IMAGE_TAG} AS builder
@@ -25,35 +25,28 @@ RUN chmod u+x ./gradlew && ./gradlew installDist
 
 # Runtime stage ###############################################################
 # Base image
-FROM bellsoft/liberica-openjdk-alpine:${RUNTIME_IMAGE_TAG} AS runtime
+FROM tomcat:${RUNTIME_IMAGE_TAG} AS runtime
 
-ARG TOMCAT_USER='tomcat9'
-ARG TOMCAT_GROUP='tomcat9'
-ENV CATALINA_HOME=/usr/share/tomcat9
+ARG TOMCAT_USER='tomcat'
+ARG TOMCAT_GROUP='tomcat'
 
-# Install Tomcat
-RUN set -ex && \
-    apk add --update-cache --no-cache \
-        --virtual runtime-deps \
-        -X https://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
-        tomcat9 bash && \
-    chmod -v u+x ${CATALINA_HOME}/bin/catalina.sh && \
-    ln -s -v ${CATALINA_HOME}/bin/catalina.sh /usr/bin/catalina.sh
+# Run as non-root user user
+RUN addgroup -g 1000 -S ${TOMCAT_GROUP} && \
+    adduser -u 1000 -G ${TOMCAT_USER} -h /citydb-wfs -S ${TOMCAT_USER} && \
+    chown -R 1000:1000 ${CATALINA_HOME}
 
 # Copy WAR to webapps folder
-COPY --from=builder --chown=${TOMCAT_USER}:${TOMCAT_GROUP} \
-    /build/build/install/3DCityDB-Web-Feature-Service/citydb-wfs.war \
-    ${CATALINA_HOME}/webapps/ROOT.war
+COPY --from=builder --chown=1000:1000 /build/build/install/3DCityDB-Web-Feature-Service/citydb-wfs.war \
+       ${CATALINA_HOME}/webapps/ROOT.war
 
-COPY --chown=${TOMCAT_USER}:${TOMCAT_GROUP} \
-    resources/docker/citydb-wfs-entrypoint.sh /usr/local/bin/
+COPY --chown=1000:1000 resources/docker/citydb-wfs-entrypoint.sh /usr/local/bin/
 
 # Delete existing ROOT context and set permissions
 RUN rm -rf ${CATALINA_HOME}/webapps/ROOT && \
     chmod a+x /usr/local/bin/citydb-wfs-entrypoint.sh
 
 WORKDIR /citydb-wfs
-USER 100
+USER 1000
 EXPOSE 8080
 
 ENTRYPOINT ["citydb-wfs-entrypoint.sh"]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright Â© 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
-#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
-#         * compound commands having a testable exit status, especially «case»;
-#         * various built-in commands including «command», «set», and «ulimit».
+#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
+#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
+#         * compound commands having a testable exit status, especially Â«caseÂ»;
+#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
 #
 #   Important for patching:
 #


### PR DESCRIPTION
* This updates the Gradle wrapper to v7.4.2
* Debian-based Docker image now uses: Tomcat 9 + JDK 17

The Alpine image cannot easily be updated, as now Tomat9 + Java 17 baseimage is available.
That's very bad, as the current `tomcat:9-alpine` image use the outdated JDK v8 in the back. This affects the Alpine image we are currently using too. 

I see these options to handle this:
* We drop the Alpine image for now because of the security threats. The Debian based image is not too heavy with ~ 269.42 MB.
* I try to build an own Tomcat9 image, e.g. based on the Alpine JDK 17 image from https://hub.docker.com/r/bellsoft/liberica-openjdk-alpine
  * Tomcat 9 is available from Alpine testing Repo, so this should be doable, but takes some time and testing.
* We add a notice to the documentation, that the Alpine image might be unsafe to use and should be avoided in production.