### PR TITLE
Prevent XXE vulnerabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 5.2.1 - tba
+
+#### Fixes
+*  Fixed XXE vulnerabilities when parsing XML files. [#12](https://github.com/3dcitydb/web-feature-service/pull/12/files)
+
 ### 5.2.0 - 2022-05-23
 
 This release is based on the Importer/Exporter version 5.2.0 libraries, and thus incorporates all bug fixes and updates

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,14 @@ repositories {
     maven {
         url 'https://citydb.jfrog.io/artifactory/maven'
     }
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
     mavenCentral()
 }
 
 dependencies {
-    implementation 'org.citydb:impexp-core:5.2.0'
+    implementation 'org.citydb:impexp-core:5.2.1-SNAPSHOT'
     implementation 'com.github.seancfoley:ipaddress:5.3.4'
     implementation 'org.glassfish.jersey.containers:jersey-container-servlet:2.35'
     implementation 'org.glassfish.jersey.inject:jersey-hk2:2.35'

--- a/src/main/java/vcs/citydb/wfs/WFSService.java
+++ b/src/main/java/vcs/citydb/wfs/WFSService.java
@@ -7,6 +7,7 @@ import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.core.util.Util;
 import org.citydb.util.concurrent.SingleWorkerPool;
 import org.citydb.util.log.Logger;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.citygml4j.builder.jaxb.CityGMLBuilder;
 import org.citygml4j.xml.schema.SchemaHandler;
 import org.xml.sax.InputSource;
@@ -90,8 +91,16 @@ public class WFSService extends HttpServlet {
 		wfsConfig = registry.lookup(WFSConfig.class);
 
 		exceptionReportHandler = new WFSExceptionReportHandler(cityGMLBuilder);
-		saxParserFactory = SAXParserFactory.newInstance();
-		saxParserFactory.setNamespaceAware(true);
+
+		try {
+			saxParserFactory = SecureXMLProcessors.newSAXParserFactory();
+			saxParserFactory.setNamespaceAware(true);
+		} catch (Throwable e) {
+			String message = "Failed to enable secure processing of XML queries.";
+			log.error(message);
+			log.error(e.getMessage());
+			throw new ServletException(message, e);
+		}
 
 		try {
 			StoredQueryManager storedQueryManager = new StoredQueryManager(cityGMLBuilder, saxParserFactory, getServletContext().getRealPath(Constants.STORED_QUERIES_PATH), wfsConfig);

--- a/src/main/java/vcs/citydb/wfs/config/WFSConfigSchemaWriter.java
+++ b/src/main/java/vcs/citydb/wfs/config/WFSConfigSchemaWriter.java
@@ -1,6 +1,6 @@
 package vcs.citydb.wfs.config;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.SchemaOutputResolver;
@@ -21,7 +21,7 @@ public class WFSConfigSchemaWriter {
 			public Result createOutput(String namespaceUri, String suggestedFileName) throws IOException {
 				File file;
 
-				if (namespaceUri.equals(ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI))
+				if (namespaceUri.equals(ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI))
 					file = new File(Constants.CONFIG_SCHEMA_FILE);
 				else
 					file = new File(Constants.CONFIG_SCHEMA_PATH + "/ows/" + suggestedFileName);

--- a/src/main/java/vcs/citydb/wfs/operation/getfeature/citygml/CityGMLWriterBuilder.java
+++ b/src/main/java/vcs/citydb/wfs/operation/getfeature/citygml/CityGMLWriterBuilder.java
@@ -10,6 +10,7 @@ import org.citydb.core.operation.common.cache.IdCacheManager;
 import org.citydb.core.operation.exporter.util.InternalConfig;
 import org.citydb.core.operation.exporter.writer.FeatureWriteException;
 import org.citydb.util.log.Logger;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.citygml4j.model.module.Module;
 import org.citygml4j.model.module.ModuleContext;
 import org.citygml4j.model.module.Modules;
@@ -29,7 +30,6 @@ import vcs.citydb.wfs.util.GeometryStripper;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
@@ -140,7 +140,7 @@ public class CityGMLWriterBuilder implements GetFeatureResponseBuilder {
 					&& wfsConfig.getPostProcessing().getXSLTransformation().isSetStylesheets()) {
 				try {
 					List<String> stylesheets = wfsConfig.getPostProcessing().getXSLTransformation().getStylesheets();
-					SAXTransformerFactory factory = (SAXTransformerFactory) TransformerFactory.newInstance();
+					SAXTransformerFactory factory = (SAXTransformerFactory) SecureXMLProcessors.newTransformerFactory();
 					Templates[] templates = new Templates[stylesheets.size()];
 
 					for (int i = 0; i < stylesheets.size(); i++) {

--- a/src/main/java/vcs/citydb/wfs/operation/getpropertyvalue/GetPropertyValueResponseBuilder.java
+++ b/src/main/java/vcs/citydb/wfs/operation/getpropertyvalue/GetPropertyValueResponseBuilder.java
@@ -8,6 +8,7 @@ import org.citydb.config.Config;
 import org.citydb.core.database.schema.mapping.FeatureType;
 import org.citydb.core.operation.exporter.writer.FeatureWriteException;
 import org.citydb.util.log.Logger;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.citygml4j.model.module.Module;
 import org.citygml4j.model.module.ModuleContext;
 import org.citygml4j.model.module.Modules;
@@ -25,7 +26,6 @@ import vcs.citydb.wfs.util.xml.NamespaceFilter;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
@@ -124,7 +124,7 @@ public class GetPropertyValueResponseBuilder {
 					&& wfsConfig.getPostProcessing().getXSLTransformation().isSetStylesheets()) {
 				try {
 					List<String> stylesheets = wfsConfig.getPostProcessing().getXSLTransformation().getStylesheets();
-					SAXTransformerFactory factory = (SAXTransformerFactory) TransformerFactory.newInstance();
+					SAXTransformerFactory factory = (SAXTransformerFactory) SecureXMLProcessors.newTransformerFactory();
 					Templates[] templates = new Templates[stylesheets.size()];
 
 					for (int i = 0; i < stylesheets.size(); i++) {


### PR DESCRIPTION
This PR adds necessary code to prevent [XXE vulnerabilities](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html) when parsing XML files. This mainly affects ad-hoc and stored WFS queries.

Note that this PR depends on [PR #258](https://github.com/3dcitydb/importer-exporter/pull/258) of the Importer/Exporter

